### PR TITLE
Add UniswapV2 contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ NOTE:
 
 ## Public addresses
 
+The addresses of the currently deployed contracts can be found in the [`/addresses.json`](./addresses.json) file.
+
 ## Improvements
 To slow down or defend against [generalized frontrunning bots](https://medium.com/@danrobinson/ethereum-is-a-dark-forest-ecc5f0505dff), consider:
 - Deploying an ownable `exchange-callee` contract and add an `auth` modifier to `clipperCall()`, so only the owner (you) can call the function

--- a/addresses.json
+++ b/addresses.json
@@ -1,14 +1,14 @@
 {
     "0x1": {
-        "UniswapV2Callee": "0x49399BB0Fcb52b32aB5A0909206BFf7B54FF80b3",
-        "UniswapV2LpTokenCallee": "0x74893C37beACf205507ea794470b13DE06294220"
+        "UniswapV2CalleeDai": "0x49399BB0Fcb52b32aB5A0909206BFf7B54FF80b3",
+        "UniswapV2LpTokenCalleeDai": "0x74893C37beACf205507ea794470b13DE06294220"
     },
     "0x5": {
-        "UniswapV2Callee": "0x6d9139ac89ad2263f138633de20e47bcae253938",
-        "UniswapV2LpTokenCallee": "0x13eba3f2dd908e3624e9fb721ea9bd2f5d46f2c0"
+        "UniswapV2CalleeDai": "0x6d9139ac89ad2263f138633de20e47bcae253938",
+        "UniswapV2LpTokenCalleeDai": "0x13eba3f2dd908e3624e9fb721ea9bd2f5d46f2c0"
     },
     "0x2a": {
-        "UniswapV2Callee": "0x5A40F810754f725DA93e2362775a0600468f7a83",
-        "UniswapV2LpTokenCallee": "0xDeC8b9c2829583A89f7F182DEeD7C12112dfAeD0"
+        "UniswapV2CalleeDai": "0x5A40F810754f725DA93e2362775a0600468f7a83",
+        "UniswapV2LpTokenCalleeDai": "0xDeC8b9c2829583A89f7F182DEeD7C12112dfAeD0"
     }
 }

--- a/addresses.json
+++ b/addresses.json
@@ -1,0 +1,14 @@
+{
+    "0x1": {
+        "UniswapV2Callee": "0x49399BB0Fcb52b32aB5A0909206BFf7B54FF80b3",
+        "UniswapV2LpTokenCallee": "0x74893C37beACf205507ea794470b13DE06294220"
+    },
+    "0x5": {
+        "UniswapV2Callee": "0x6d9139ac89ad2263f138633de20e47bcae253938",
+        "UniswapV2LpTokenCallee": "0x13eba3f2dd908e3624e9fb721ea9bd2f5d46f2c0"
+    },
+    "0x2a": {
+        "UniswapV2Callee": "0x5A40F810754f725DA93e2362775a0600468f7a83",
+        "UniswapV2LpTokenCallee": "0xDeC8b9c2829583A89f7F182DEeD7C12112dfAeD0"
+    }
+}


### PR DESCRIPTION
As per discussion on Discord: let's keep latest contract addresses in the repo in a machine-readable format so it can be shared across other projects.

File format proposal:
- Format: JSON
- Filename: `/addresses.json`
- Root keys: chain ids in a hex format
- Sub keys: contract names