### PR TITLE
UniswapV2LockstakeCallee renamings

### DIFF
--- a/addresses.json
+++ b/addresses.json
@@ -4,7 +4,8 @@
         "UniswapV2LpTokenCalleeDai": "0x74893C37beACf205507ea794470b13DE06294220",
         "UniswapV3Callee": "0xdB9C76109d102d2A1E645dCa3a7E671EBfd8e11A",
         "WstETHCurveUniv3Callee": "0x21540b2653FeBa52eE2c8714CA7Abfb522bb5e8C",
-        "CurveLpTokenUniv3Callee": "0x71f2198849F3B1372EA90c079BD634928583f2d2"
+        "CurveLpTokenUniv3Callee": "0x71f2198849F3B1372EA90c079BD634928583f2d2",
+        "UniswapV2LockstakeCallee": "0xf68424845e4Af5b771356d504965A3c9257805f3"
     },
     "0x5": {
         "UniswapV2CalleeDai": "0x6d9139ac89ad2263f138633de20e47bcae253938",

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.21"
+optimizer = true
+optimizer_runs = 200
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/test/UniswapV2LockstakeCallee.t.sol
+++ b/src/test/UniswapV2LockstakeCallee.t.sol
@@ -421,7 +421,7 @@ contract UniswapV2LockstakeCalleeTest is DssTest {
         _testCalleeTake(true, true, uniV2Path, uniV2Price * mkrSky.rate());
     }
 
-    // --- Callee tests using Sky/DAI path ---
+    // --- Callee tests using SKY/DAI path ---
 
     function testCalleeTake_NoDelegate_NoStaking_SkyDai() public {
         setUpCallee();


### PR DESCRIPTION
Updates LockstakeClipper Callee originally developed [here](https://github.com/makerdao/exchange-callees/pull/43) after the latest rebranding (and [public audit contest](https://audits.sherlock.xyz/contests/333?filter=questions))
- Lockstake submodule is updated to the [latest audited version](https://www.chainsecurity.com/security-audit/makerdao-lockstake-smart-contracts)
- Token names updated

Note: to run only relevant tests, one can execute `forge test --match-contract=UniswapV2LockstakeCalleeTest`
